### PR TITLE
- corrections at appveyor.yml config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,10 +36,10 @@ build:
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"\src
     - if "%PlatformToolset%"=="v140" msbuild CSScriptNpp.sln  /p:configuration="%configuration%" /p:platform="%platform_input%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-    - if "%PlatformToolset%"=="v141" msbuild CSScriptNpp.2017.sln  /p:configuration="%configuration%" /p:platform="%platform_input%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - if "%PlatformToolset%"=="v141" msbuild CSScriptNpp.2017.sln /m /p:configuration="%configuration%" /p:platform="%platform_input%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
-    - cd "%APPVEYOR_BUILD_FOLDER%"\CSScriptNpp
+    - cd "%APPVEYOR_BUILD_FOLDER%"\src\CSScriptNpp
     - ps: >-
 
         if ($env:PLATFORM -eq "x64" -and $env:CONFIGURATION -eq "Release") {
@@ -50,7 +50,7 @@ after_build:
             Push-AppveyorArtifact "bin\$env:PLATFORM\$env:CONFIGURATION\CSScriptNpp.dll" -FileName CSScriptNpp.dll
         }
 
-        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140") {
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141") {
             if($env:PLATFORM -eq "x64"){
             $ZipFileName = "CSScriptNpp_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
             7z a $ZipFileName bin\$env:PLATFORM\$env:CONFIGURATION\CSScriptNpp.dll
@@ -75,5 +75,5 @@ deploy:
     force_update: true
     on:
         appveyor_repo_tag: true
-        PlatformToolset: v140
+        PlatformToolset: v141
         configuration: Release


### PR DESCRIPTION
- use v141 for deployment tests

, see https://ci.appveyor.com/project/chcg/cs-script-npp/build/1.7.6.24

- Seems another file (NppShortcutRemapper.exe) is missing:

PreBuildEvent:
  copy "C:\projects\cs-script-npp\src\CSScriptIntellisense\..\NppShortcutRemapper\bin\NppShortcutRemapper.exe" "C:\projects\cs-script-npp\src\CSScriptIntellisense\Resources\NppShortcutRemapper.exe"

- xunit tests are running, see https://ci.appveyor.com/project/chcg/cs-script-npp/build/1.7.6.24/job/vxc4s2l2t8pyda7x/tests
, but most of them are failing, because RoslynIntellisense.exe could not be found as it is searched for like in the N++ plugin installation configuration by CSScriptIntellisense.RoslynCompletionEngine.Init() 

                var file = Roslyn.LocateInPluginDir("RoslynIntellisense.exe", "Roslyn", @".\");

Filepath is something like:
"C:\\Users\\XXX\\AppData\\Local\\Temp\\99a134b2-8e5f-4ca6-ae02-05b468e30091\\99a134b2-8e5f-4ca6-ae02-05b468e30091\\assembly\\dl3\\ef37f93b\\c0660d5c_5a5ed301\\RoslynIntellisense.exe"

Is it necessary to set roslynintellisense_path for running the unittests?

