### PR TITLE
avoid compiler warnings:

### DIFF
--- a/src/CSScriptIntellisense/CSharpIntellisense/RoslynCompletionEngine.cs
+++ b/src/CSScriptIntellisense/CSharpIntellisense/RoslynCompletionEngine.cs
@@ -32,7 +32,7 @@ namespace CSScriptIntellisense
         public delegate void D2(string s);
 
         static IEngine engine;
-        static Assembly intellisense;
+        //static Assembly intellisense;
 
         public static IEngine GetInstance()
         {

--- a/src/CSScriptIntellisense/Formatter/SourceCodeFormatter.cs
+++ b/src/CSScriptIntellisense/Formatter/SourceCodeFormatter.cs
@@ -122,7 +122,7 @@ namespace CSScriptIntellisense
 
         delegate string FormatMethod(string code, string file);
 
-        static FormatMethod RoslynFormat;
+        //static FormatMethod RoslynFormat;
 
         static string FormatCodeWithRoslyn(string code, ref int pos, string file)
         {

--- a/src/Intellisense.Interface/Intellisense.Common.csproj
+++ b/src/Intellisense.Interface/Intellisense.Common.csproj
@@ -37,7 +37,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/launcher/launcher.csproj
+++ b/src/launcher/launcher.csproj
@@ -43,7 +43,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The field 'RoslynCompletionEngine_old.intellisense' is never used CSharpIntellisense\RoslynCompletionEngine.cs 35 25 CSScriptIntellisense.2017

The field 'SourceCodeFormatter.RoslynFormat' is never used Formatter\SourceCodeFormatter.cs 125 29 CSScriptIntellisense.2017

The primary reference "System.Net.Http", which is a framework assembly, could not be resolved in the currently targeted framework. ".NETFramework,Version=v4.0". To resolve this problem, either remove the reference "System.Net.Http" or retarget your application to a framework version which contains "System.Net.Http".
..\..\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\bin\Microsoft.Common.CurrentVersion.targets
2041 5 Intellisense.Common

The primary reference "System.Net.Http", which is a framework assembly, could not be resolved in the currently targeted framework. ".NETFramework,Version=v4.0". To resolve this problem, either remove the reference "System.Net.Http" or retarget your application to a framework version which contains "System.Net.Http".
..\..\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\bin\Microsoft.Common.CurrentVersion.targets
2041 5 launcher